### PR TITLE
docs: tweaked project setup and clone instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
 
 # Cloning the Heroes Profile repository
  * `git clone --recursive https://github.com/Zemill/heroesprofile.git`
+ * `cd heroesprofile`
  * `git submodule update --remote`
  * If you have issues getting the seed files to populate in `database/seeds/heroesprofile-seeds/seed-files`, you can pull them directly from https://github.com/Zemill/heroesprofile-seeds.git
 
@@ -38,8 +39,8 @@
  #Project Setup
  * From the command line, navigate to the heroesprofile repository.
  * Configure `.env` file using `.env.example`
- * Run `php artisan key:generate` make sure the APP_KEY has this value in the .env file
  * Run `composer install`
+ * Run `php artisan key:generate` make sure the APP_KEY has this value in the .env file
  * Run `npm install`
  * Run `php artisan migrate`
  * Run `composer dump-autoload`


### PR DESCRIPTION
`composer install` is required before `php artisan key:generate` in order to run successfully
also during the `git clone` you need to `cd` into the new dir before you can update submodules